### PR TITLE
docs: add comprehensive godoc comments to core API

### DIFF
--- a/casbin.go
+++ b/casbin.go
@@ -14,18 +14,37 @@ import (
 //go:embed configs/casbin_model.conf
 var CasbinModelText string
 
+// CasbinModel loads the embedded casbin RBAC model configuration and returns
+// a parsed model.Model ready to be passed to a casbin Enforcer.
 func CasbinModel() (model.Model, error) {
 	return model.NewModelFromString(CasbinModelText)
 }
 
+// WatcherOption configures an optional casbin policy watcher that keeps
+// multiple enforcer instances in sync when the policy changes.
 type WatcherOption struct {
-	Type     string `json:"type"`
-	Address  string `json:"address"`
+	// Type selects the watcher backend. Currently "redis" is supported.
+	// An empty or unrecognised type falls back to auto-load polling when
+	// AutoLoad > 0.
+	Type string `json:"type"`
+	// Address is the host:port of the watcher backend (e.g. "localhost:6379").
+	Address string `json:"address"`
+	// Password is the authentication password for the watcher backend.
 	Password string `json:"password"`
-	Channel  string `json:"channel"`
-	AutoLoad int64  `json:"auto_load"`
+	// Channel is the pub/sub channel name used by the Redis watcher.
+	Channel string `json:"channel"`
+	// AutoLoad, when > 0 and Type is not "redis", sets the interval in
+	// seconds for the enforcer's built-in StartAutoLoadPolicy poller.
+	AutoLoad int64 `json:"auto_load"`
 }
 
+// SetWatcher attaches a policy watcher to the given casbin enforcer based on
+// the provided [WatcherOption]. If option is nil, SetWatcher is a no-op.
+//
+// Supported watcher types:
+//   - "redis": sets up a Redis pub/sub watcher via github.com/casbin/redis-watcher.
+//   - "": or unknown type with AutoLoad > 0 — enables the enforcer's built-in
+//     periodic policy reload via StartAutoLoadPolicy.
 func SetWatcher(e casbin.IEnforcer, option *WatcherOption) error {
 	if option == nil {
 		return nil
@@ -66,44 +85,82 @@ type startAutoLoadPolicyInterface interface {
 	StartAutoLoadPolicy(time.Duration)
 }
 
+// IEnforcer is the caskin-internal interface that wraps casbin's enforcer with
+// domain-aware, strongly-typed methods. All parameters and return values use
+// the caskin domain model types ([User], [Role], [Object], [Domain], [Action],
+// [Policy]) rather than raw strings.
+//
+// Obtain an IEnforcer via [NewEnforcer].
 type IEnforcer interface {
+	// Enforce checks whether user u can perform action on object o within domain d.
 	Enforce(User, Object, Domain, Action) (bool, error)
+	// EnforceRole checks whether son inherits from parent within domain.
 	EnforceRole(son Role, parent Role, domain Domain) (bool, error)
+	// EnforceObject checks whether son is a descendant of parent within domain.
 	EnforceObject(son Object, parent Object, domain Domain) (bool, error)
+	// IsSuperadmin returns true if user is a global superadmin.
 	IsSuperadmin(User) (bool, error)
 
+	// GetDomainsIncludeUser returns every domain the user belongs to.
 	GetDomainsIncludeUser(User) []Domain
 
+	// GetRolesForUserInDomain returns the roles directly assigned to user in domain.
 	GetRolesForUserInDomain(User, Domain) []Role
+	// GetUsersForRoleInDomain returns the users that have role in domain.
 	GetUsersForRoleInDomain(Role, Domain) []User
+	// GetParentsForRoleInDomain returns the parent roles of role in domain.
 	GetParentsForRoleInDomain(Role, Domain) []Role
+	// GetChildrenForRoleInDomain returns the child roles of role in domain.
 	GetChildrenForRoleInDomain(Role, Domain) []Role
+	// GetParentsForObjectInDomain returns the parent objects of object in domain.
 	GetParentsForObjectInDomain(Object, Domain) []Object
+	// GetChildrenForObjectInDomain returns the child objects of object in domain.
 	GetChildrenForObjectInDomain(Object, Domain) []Object
+	// GetPoliciesForRoleInDomain returns all policies granted to role in domain.
 	GetPoliciesForRoleInDomain(Role, Domain) []*Policy
+	// GetPoliciesForObjectInDomain returns all policies that reference object in domain.
 	GetPoliciesForObjectInDomain(Object, Domain) []*Policy
 
+	// RemoveUserInDomain removes all role assignments for user within domain.
 	RemoveUserInDomain(User, Domain) error
+	// RemoveRoleInDomain removes all policies, inheritance edges, and user
+	// assignments associated with role within domain.
 	RemoveRoleInDomain(Role, Domain) error
+	// RemoveObjectInDomain removes all policies and hierarchy edges associated
+	// with object within domain.
 	RemoveObjectInDomain(Object, Domain) error
 
+	// AddPolicyInDomain grants role the given action on object within domain.
 	AddPolicyInDomain(Role, Object, Domain, Action) error
+	// RemovePolicyInDomain revokes role's action on object within domain.
 	RemovePolicyInDomain(Role, Object, Domain, Action) error
 
+	// AddRoleForUserInDomain assigns role to user within domain.
 	AddRoleForUserInDomain(User, Role, Domain) error
+	// RemoveRoleForUserInDomain unassigns role from user within domain.
 	RemoveRoleForUserInDomain(User, Role, Domain) error
 
+	// AddParentForRoleInDomain makes son inherit from parent within domain.
 	AddParentForRoleInDomain(Role, Role, Domain) error
+	// RemoveParentForRoleInDomain removes the son→parent inheritance in domain.
 	RemoveParentForRoleInDomain(Role, Role, Domain) error
 
+	// AddParentForObjectInDomain makes son a child of parent within domain.
 	AddParentForObjectInDomain(Object, Object, Domain) error
+	// RemoveParentForObjectInDomain removes the son→parent object edge in domain.
 	RemoveParentForObjectInDomain(Object, Object, Domain) error
 
+	// GetUsersInDomain returns all users that have any role in domain.
 	GetUsersInDomain(Domain) []User
+	// GetRolesInDomain returns all roles defined in domain.
 	GetRolesInDomain(Domain) []Role
+	// GetObjectsInDomain returns all objects defined in domain.
 	GetObjectsInDomain(Domain) []Object
+	// GetPoliciesInDomain returns all policies defined in domain.
 	GetPoliciesInDomain(Domain) []*Policy
 
+	// RemoveUsersInDomain removes all user→role assignments within domain,
+	// effectively clearing the domain's user membership.
 	RemoveUsersInDomain(Domain) error
 }
 
@@ -460,6 +517,8 @@ func (e *enforcer) RemoveUsersInDomain(domain Domain) error {
 	return err
 }
 
+// NewEnforcer wraps a casbin enforcer and a [Factory] into an [IEnforcer].
+// The factory is used to decode casbin string tokens back into typed caskin values.
 func NewEnforcer(e casbin.IEnforcer, factory Factory) IEnforcer {
 	return &enforcer{
 		e:       e,

--- a/constant.go
+++ b/constant.go
@@ -1,29 +1,48 @@
 package caskin
 
 const (
+	// ObjectPType is the casbin named-policy type used for object hierarchy
+	// edges (parent→child relationships between Objects).
 	ObjectPType = "g2"
 
-	SuperadminRole   = "superadmin"
+	// SuperadminRole is the casbin role name reserved for the superadmin role.
+	// It is used in the dedicated superadmin domain and bypasses all normal
+	// permission checks.
+	SuperadminRole = "superadmin"
+
+	// SuperadminDomain is the casbin domain name reserved for the superadmin
+	// scope. Assignments in this domain confer superadmin privileges.
 	SuperadminDomain = "superdomain"
 )
 
 const (
-	Read   Action = "read"
-	Write  Action = "write"
+	// Read is the read permission action.
+	Read Action = "read"
+	// Write is the write/create/update permission action.
+	Write Action = "write"
+	// Manage is the administrative permission action, which typically implies
+	// Read and Write as well.
 	Manage Action = "manage"
 )
 
 const (
+	// ObjectTypeRole is the built-in ObjectType for Role objects.
+	// Roles are stored as ObjectData with this type.
 	ObjectTypeRole ObjectType = "role"
 )
 
 const (
+	// DirectorySearchAll traverses the entire subtree rooted at the given node.
 	DirectorySearchAll DirectorySearchType = "all"
+	// DirectorySearchTop returns only the direct children of the given node.
 	DirectorySearchTop DirectorySearchType = "top"
 )
 
 const (
-	UpsertTypeCreate  UpsertType = "create"
+	// UpsertTypeCreate indicates the upsert operation created a new record.
+	UpsertTypeCreate UpsertType = "create"
+	// UpsertTypeRecover indicates the upsert operation recovered a soft-deleted record.
 	UpsertTypeRecover UpsertType = "recover"
-	UpsertTypeUpdate  UpsertType = "update"
+	// UpsertTypeUpdate indicates the upsert operation updated an existing record.
+	UpsertTypeUpdate UpsertType = "update"
 )

--- a/dictionary.go
+++ b/dictionary.go
@@ -1,22 +1,41 @@
 package caskin
 
+// IDictionary combines the feature dictionary and the creator dictionary
+// into a single interface. Implementations provide the static configuration
+// for features (backends, frontends) and the seed data for creator objects,
+// roles, and policies.
 type IDictionary interface {
 	IFeatureDictionary
 	ICreatorDictionary
 }
 
+// IFeatureDictionary provides read access to the feature registry that
+// defines available backends (API endpoints) and frontend (UI element) guards.
 type IFeatureDictionary interface {
+	// GetFeature returns all registered features.
 	GetFeature() ([]*Feature, error)
+	// GetBackend returns all registered backend permission guards.
 	GetBackend() ([]*Backend, error)
+	// GetFrontend returns all registered frontend permission guards.
 	GetFrontend() ([]*Frontend, error)
+	// GetFeatureByKey looks up a feature by its unique key.
 	GetFeatureByKey(key string) (*Feature, error)
+	// GetBackendByKey looks up a backend guard by its unique key.
 	GetBackendByKey(key string) (*Backend, error)
+	// GetFrontendByKey looks up a frontend guard by its unique key.
 	GetFrontendByKey(key string) (*Frontend, error)
+	// GetPackage returns all feature packages (bundles of features).
 	GetPackage() ([]*Package, error)
 }
 
+// ICreatorDictionary provides the seed data used to initialise a new domain.
+// When [IBaseService.CreateDomain] is called, these objects, roles, and
+// policies are created automatically.
 type ICreatorDictionary interface {
+	// GetCreatorObject returns the object templates to seed into a new domain.
 	GetCreatorObject() ([]*CreatorObject, error)
+	// GetCreatorRole returns the role templates to seed into a new domain.
 	GetCreatorRole() ([]*CreatorRole, error)
+	// GetCreatorPolicy returns the policy templates to seed into a new domain.
 	GetCreatorPolicy() ([]*CreatorPolicy, error)
 }

--- a/doc.go
+++ b/doc.go
@@ -1,0 +1,50 @@
+// Package caskin provides a multi-domain RBAC (Role-Based Access Control)
+// permission management library built on top of casbin.
+//
+// # Overview
+//
+// caskin extends casbin's RBAC model to support multiple isolated domains,
+// where each domain has its own set of roles, objects, and policies. This
+// allows you to build multi-tenant applications where each tenant (domain)
+// has fully isolated permissions.
+//
+// # Core Concepts
+//
+//   - User: An entity that can be assigned roles within a domain.
+//   - Domain: An isolated permission scope (e.g., a tenant or organization).
+//   - Role: A named set of permissions within a domain; roles can be hierarchical.
+//   - Object: A resource that can be accessed; objects form a tree hierarchy.
+//   - ObjectData: A domain-specific data item associated with an Object type.
+//   - Policy: A tuple of (Role, Object, Domain, Action) granting a role
+//     permission to perform an action on an object within a domain.
+//   - Action: One of read, write, or manage.
+//
+// # Quick Start
+//
+//	// 1. Define your own User, Role, Object, Domain types (implement the
+//	//    corresponding interfaces), then register them with caskin:
+//	caskin.Register[*MyUser, *MyRole, *MyObject, *MyDomain]()
+//
+//	// 2. Create a service instance:
+//	svc, err := caskin.New(&caskin.Options{
+//	    DB: &caskin.DBOption{DSN: "..."},
+//	})
+//
+//	// 3. Use the service to manage permissions:
+//	svc.CreateDomain(domain)
+//	svc.CreateRole(admin, domain, role)
+//	svc.AddUserRole(admin, domain, []*caskin.UserRolePair{{User: user, Role: role}})
+//
+// # Superadmin
+//
+// caskin has a special "superadmin" role that transcends all domain
+// boundaries. Superadmins can manage any domain and bypass all permission
+// checks. Use [IBaseService.AddSuperadmin] / [IBaseService.DeleteSuperadmin]
+// to manage superadmin users.
+//
+// # Directory
+//
+// Objects can be organized into tree-structured directories. The
+// [IDirectoryService] provides operations to create, move, copy, and
+// delete directory nodes and their contents.
+package caskin

--- a/error.go
+++ b/error.go
@@ -2,24 +2,61 @@ package caskin
 
 import "fmt"
 
+// Sentinel errors returned by caskin operations.
+//
+// Callers should use errors.Is to check for specific errors:
+//
+//	if errors.Is(err, caskin.ErrNoReadPermission) { ... }
 var (
-	ErrNil                   = fmt.Errorf("nil data")
-	ErrEmptyID               = fmt.Errorf("empty id")
-	ErrAlreadyExists         = fmt.Errorf("already exists")
-	ErrNotExists             = fmt.Errorf("not exists")
-	ErrInValidObject         = fmt.Errorf("invalid object")
-	ErrInValidObjectType     = fmt.Errorf("invalid object type")
-	ErrCantChangeObjectType  = fmt.Errorf("can't change object type")
+	// ErrNil is returned when a required argument is nil.
+	ErrNil = fmt.Errorf("nil data")
+	// ErrEmptyID is returned when an entity has an unset (zero) ID.
+	ErrEmptyID = fmt.Errorf("empty id")
+	// ErrAlreadyExists is returned when trying to create an entity that
+	// already exists (non-deleted) in the database.
+	ErrAlreadyExists = fmt.Errorf("already exists")
+	// ErrNotExists is returned when the target entity cannot be found.
+	ErrNotExists = fmt.Errorf("not exists")
+	// ErrInValidObject is returned when the object reference is invalid or
+	// does not belong to the current domain.
+	ErrInValidObject = fmt.Errorf("invalid object")
+	// ErrInValidObjectType is returned when the object type string is not
+	// registered in the current factory.
+	ErrInValidObjectType = fmt.Errorf("invalid object type")
+	// ErrCantChangeObjectType is returned when an update attempts to change
+	// an existing object's type, which is not allowed.
+	ErrCantChangeObjectType = fmt.Errorf("can't change object type")
+	// ErrCantOperateRootObject is returned when an operation would affect the
+	// root object of a domain, which is protected.
 	ErrCantOperateRootObject = fmt.Errorf("can't operate root object")
-	ErrParentCanNotBeItself  = fmt.Errorf("parent id can't be it self id")
-	ErrParentToDescendant    = fmt.Errorf("can't change parent to descendant")
-	ErrInValidRequest        = fmt.Errorf("invalid request")
+	// ErrParentCanNotBeItself is returned when an object's parent ID is set
+	// to its own ID, which would create a self-loop.
+	ErrParentCanNotBeItself = fmt.Errorf("parent id can't be it self id")
+	// ErrParentToDescendant is returned when moving an object would make its
+	// new parent one of its own descendants, creating a cycle.
+	ErrParentToDescendant = fmt.Errorf("can't change parent to descendant")
+	// ErrInValidRequest is returned when the [DirectoryRequest] parameters
+	// are inconsistent or missing required fields.
+	ErrInValidRequest = fmt.Errorf("invalid request")
 
-	ErrNoReadPermission    = fmt.Errorf("no read permission")
-	ErrNoWritePermission   = fmt.Errorf("no write permission")
-	ErrNoManagePermission  = fmt.Errorf("no manage permission")
+	// ErrNoReadPermission is returned when the caller lacks read access to
+	// the target object/domain.
+	ErrNoReadPermission = fmt.Errorf("no read permission")
+	// ErrNoWritePermission is returned when the caller lacks write access to
+	// the target object/domain.
+	ErrNoWritePermission = fmt.Errorf("no write permission")
+	// ErrNoManagePermission is returned when the caller lacks manage access
+	// to the target object/domain.
+	ErrNoManagePermission = fmt.Errorf("no manage permission")
+	// ErrNoBackendPermission is returned when [IFeatureService.AuthBackend]
+	// determines the caller is not authorised for the given backend endpoint.
 	ErrNoBackendPermission = fmt.Errorf("no backend api permission")
 
+	// ErrIsNotSuperadmin is returned when a superadmin-only operation is
+	// attempted by a non-superadmin user, or when decoding a superadmin
+	// token fails.
 	ErrIsNotSuperadmin = fmt.Errorf("is not superadmin")
-	ErrInValidCurrent  = fmt.Errorf("invalid current api")
+	// ErrInValidCurrent is returned when [ICurrentService] methods are called
+	// before [ICurrentService.SetCurrent] has been called.
+	ErrInValidCurrent = fmt.Errorf("invalid current api")
 )

--- a/inheritance.go
+++ b/inheritance.go
@@ -6,36 +6,53 @@ import (
 	"slices"
 )
 
-// InheritanceEdge x is node, y is adjacency
+// InheritanceEdge represents a directed edge in an inheritance graph where
+// U is the parent node and V is the child node. It is used to serialise
+// role/object hierarchy edges for storage and comparison.
 type InheritanceEdge[T cmp.Ordered] struct {
 	U T `json:"u"`
 	V T `json:"v"`
 }
 
+// Encode stores the (u, v) pair and returns the JSON string representation.
 func (i *InheritanceEdge[T]) Encode(u, v T) string {
 	i.U, i.V = u, v
 	b, _ := json.Marshal(i)
 	return string(b)
 }
 
+// Decode parses a JSON string produced by [InheritanceEdge.Encode] back into
+// the edge struct.
 func (i *InheritanceEdge[T]) Decode(in string) error {
 	return json.Unmarshal([]byte(in), i)
 }
 
+// EdgeSorter maps node values to their topological sort order. It is used to
+// sort slices of [InheritanceEdge] so that root nodes come first
+// ([EdgeSorter.RootFirstSort]) or leaf nodes come first
+// ([EdgeSorter.LeafFirstSort]).
 type EdgeSorter[T cmp.Ordered] map[T]int
 
+// RootFirstSort sorts edges so that edges whose source (U) is closer to the
+// root of the graph come first. This is useful for processing parent nodes
+// before their children.
 func (e EdgeSorter[T]) RootFirstSort(edges []*InheritanceEdge[T]) {
 	slices.SortFunc(edges, func(a, b *InheritanceEdge[T]) int {
 		return cmp.Compare(e[a.U], e[b.U])
 	})
 }
 
+// LeafFirstSort sorts edges so that edges whose destination (V) is closer to
+// the leaves of the graph come first. This is useful for processing children
+// before their parents (e.g. when deleting a subtree).
 func (e EdgeSorter[T]) LeafFirstSort(edges []*InheritanceEdge[T]) {
 	slices.SortFunc(edges, func(a, b *InheritanceEdge[T]) int {
 		return cmp.Compare(e[b.V], e[a.V])
 	})
 }
 
+// NewEdgeSorter builds an [EdgeSorter] from a topological ordering of node
+// values. Nodes that appear earlier in order are considered closer to the root.
 func NewEdgeSorter[T cmp.Ordered](order []T) EdgeSorter[T] {
 	sorter := map[T]int{}
 	for i, v := range order {
@@ -44,8 +61,13 @@ func NewEdgeSorter[T cmp.Ordered](order []T) EdgeSorter[T] {
 	return sorter
 }
 
+// InheritanceGraph is an adjacency list representation of a directed graph
+// where each key is a node and the associated slice contains its direct
+// children (nodes it inherits into).
 type InheritanceGraph[T cmp.Ordered] map[T][]T
 
+// Sort returns a new [InheritanceGraph] where the keys and each adjacency list
+// are sorted, making the graph representation deterministic.
 func (g InheritanceGraph[T]) Sort() InheritanceGraph[T] {
 	var keys []T
 	for k := range g {
@@ -61,6 +83,10 @@ func (g InheritanceGraph[T]) Sort() InheritanceGraph[T] {
 	return m
 }
 
+// TopSort performs a topological sort (Kahn's algorithm / BFS) on the graph
+// and returns the nodes in an order where every parent appears before all of
+// its children. The graph must be a DAG; cycles will cause nodes to be omitted
+// from the result.
 func (g InheritanceGraph[T]) TopSort() []T {
 	inDegree := map[T]int{}
 	for k := range g {
@@ -104,6 +130,9 @@ func distinct[T cmp.Ordered](s []T) []T {
 	return out
 }
 
+// MergeInheritanceGraph merges multiple [InheritanceGraph] values into one,
+// deduplicating adjacency entries and sorting the result. This is useful when
+// combining role/object inheritance rules from multiple sources.
 func MergeInheritanceGraph[T cmp.Ordered](graphs ...InheritanceGraph[T]) InheritanceGraph[T] {
 	m := InheritanceGraph[T]{}
 	for _, graph := range graphs {

--- a/metadata.go
+++ b/metadata.go
@@ -1,22 +1,53 @@
 package caskin
 
+// UpsertType describes the outcome of a database upsert operation performed
+// by [MetaDB]. See [UpsertTypeCreate], [UpsertTypeRecover], and
+// [UpsertTypeUpdate] for the possible values.
 type UpsertType string
 
+// MetaDB is the storage abstraction used by caskin to persist Users, Roles,
+// Objects, Domains, and ObjectData. Provide a concrete implementation (or use
+// the built-in GORM-backed one via [Register]) to connect caskin to your
+// database.
+//
+// The interface deliberately remains generic (operating on any) for Create,
+// Recover, Update, and similar operations so that it can handle all entity
+// types without requiring separate methods per type.
 type MetaDB interface {
+	// Create inserts a new record. The entity must not already exist (not
+	// soft-deleted). Returns [ErrAlreadyExists] if a live record is found.
 	Create(any) error
+	// Recover undeletes a soft-deleted record. Returns [ErrNotExists] if no
+	// deleted record is found.
 	Recover(any) error
+	// Update saves changes to an existing record.
 	Update(any) error
+	// UpsertType determines whether the next Upsert will create, recover, or
+	// update; it does not perform any write itself.
 	UpsertType(any) UpsertType
+	// Take loads a single live (not soft-deleted) record by primary key.
 	Take(any) error
+	// TakeUnscoped loads a single record regardless of soft-delete status.
 	TakeUnscoped(any) error
+	// Find loads all matching records into the destination slice, with optional
+	// filter conditions forwarded to the underlying ORM.
 	Find(any, ...any) error
+	// DeleteByID soft-deletes the record of the given type with the specified ID.
 	DeleteByID(any, uint64) error
 
+	// GetUserByID fetches [User] records for the given IDs.
 	GetUserByID([]uint64) ([]User, error)
+	// GetRoleInDomain fetches all [Role] records that belong to the given domain.
 	GetRoleInDomain(Domain) ([]Role, error)
+	// GetRoleByID fetches [Role] records for the given IDs.
 	GetRoleByID([]uint64) ([]Role, error)
+	// GetObjectInDomain fetches all [Object] records in the given domain,
+	// optionally filtered by one or more [ObjectType] values.
 	GetObjectInDomain(Domain, ...ObjectType) ([]Object, error)
+	// GetObjectByID fetches [Object] records for the given IDs.
 	GetObjectByID([]uint64) ([]Object, error)
+	// GetDomainByID fetches [Domain] records for the given IDs.
 	GetDomainByID([]uint64) ([]Domain, error)
+	// GetAllDomain fetches every [Domain] record in the database.
 	GetAllDomain() ([]Domain, error)
 }

--- a/metadata_database.go
+++ b/metadata_database.go
@@ -9,11 +9,17 @@ import (
 	"gorm.io/gorm"
 )
 
+// DBOption holds the configuration for the metadata database connection.
+// Pass it as part of [Options] when constructing a caskin service via [New].
 type DBOption struct {
-	DSN  string `json:"dsn"`
+	// DSN is the data source name (connection string) for the database.
+	DSN string `json:"dsn"`
+	// Type selects the database driver. Supported values: "sqlite", "mysql"
+	// (default when empty), and "postgres".
 	Type string `json:"type"`
 }
 
+// NewDB opens a GORM database connection using the configured driver and DSN.
 func (o *DBOption) NewDB() (*gorm.DB, error) {
 	dialect, err := getDialect(o.Type, o.DSN)
 	if err != nil {

--- a/options.go
+++ b/options.go
@@ -1,20 +1,35 @@
 package caskin
 
+// Default names used when no overrides are provided via [Options].
 var (
-	DefaultSuperadminRoleName   = "superadmin_role"
+	// DefaultSuperadminRoleName is the default name for the superadmin role
+	// stored in the casbin policy. Override via [Options.DefaultSuperadminRoleName].
+	DefaultSuperadminRoleName = "superadmin_role"
+	// DefaultSuperadminDomainName is the default name for the superadmin domain.
+	// Override via [Options.DefaultSuperadminDomainName].
 	DefaultSuperadminDomainName = "superadmin_domain"
 )
 
+// Option is a functional option that mutates an [Options] struct.
+// Pass one or more Options to [New] to customise the service.
 type Option func(*Options)
 
-// Options configuration for caskin
+// Options holds the configuration for creating a caskin [IService] via [New].
 type Options struct {
-	// default caskin option
-	DefaultSuperadminDomainName string            `json:"default_superadmin_domain_name"`
-	DefaultSuperadminRoleName   string            `json:"default_superadmin_role_name"`
-	Dictionary                  *DictionaryOption `json:"dictionary"`
-	DB                          *DBOption         `json:"db"`
-	Watcher                     *WatcherOption    `json:"watcher"`
+	// DefaultSuperadminDomainName overrides the built-in superadmin domain name
+	// (default: "superadmin_domain"). Must match the name used in the database.
+	DefaultSuperadminDomainName string `json:"default_superadmin_domain_name"`
+	// DefaultSuperadminRoleName overrides the built-in superadmin role name
+	// (default: "superadmin_role"). Must match the name stored in casbin.
+	DefaultSuperadminRoleName string `json:"default_superadmin_role_name"`
+	// Dictionary configures the feature/creator dictionary backend. If nil,
+	// an empty in-memory dictionary is used.
+	Dictionary *DictionaryOption `json:"dictionary"`
+	// DB configures the metadata database connection.
+	DB *DBOption `json:"db"`
+	// Watcher configures the optional casbin policy watcher (e.g. Redis).
+	// When nil, no watcher is set up.
+	Watcher *WatcherOption `json:"watcher"`
 }
 
 func (o *Options) newOptions(opts ...Option) *Options {

--- a/register.go
+++ b/register.go
@@ -7,20 +7,46 @@ import (
 	"gorm.io/gorm"
 )
 
+// defaultFactory holds the singleton Factory set by Register.
 var defaultFactory Factory
 
+// Factory is the type registry used by caskin to instantiate and decode
+// concrete User, Role, Object, and Domain values from their string
+// representations stored in casbin.
+//
+// Call [Register] once at program startup with your concrete types, then
+// use [DefaultFactory] to access the registered factory throughout your
+// application.
 type Factory interface {
+	// User decodes a casbin subject string into a User.
 	User(string) (User, error)
+	// Role decodes a casbin role string into a Role.
 	Role(string) (Role, error)
+	// Object decodes a casbin object string into an Object.
 	Object(string) (Object, error)
+	// Domain decodes a casbin domain string into a Domain.
 	Domain(string) (Domain, error)
+	// NewUser returns a zero-value User of the registered concrete type.
 	NewUser() User
+	// NewRole returns a zero-value Role of the registered concrete type.
 	NewRole() Role
+	// NewObject returns a zero-value Object of the registered concrete type.
 	NewObject() Object
+	// NewDomain returns a zero-value Domain of the registered concrete type.
 	NewDomain() Domain
+	// MetadataDB wraps the given GORM database with the registered type
+	// information and returns a [MetaDB] implementation.
 	MetadataDB(db *gorm.DB) MetaDB
 }
 
+// Register wires up the global type factory with the caller's concrete
+// implementations of [User], [Role], [Object], and [Domain]. It must be called
+// exactly once before creating any caskin service via [New].
+//
+// All four type parameters must be pointer types that implement their
+// respective interfaces:
+//
+//	caskin.Register[*MyUser, *MyRole, *MyObject, *MyDomain]()
 func Register[U User, R Role, O Object, D Domain]() {
 	b := &builtinRegister[U, R, O, D]{}
 	b.user = append(b.user, b.NewUser())
@@ -32,6 +58,8 @@ func Register[U User, R Role, O Object, D Domain]() {
 	defaultFactory = b
 }
 
+// DefaultFactory returns the global [Factory] set by the most recent call to
+// [Register]. It panics (via nil-pointer) if [Register] has not been called.
 func DefaultFactory() Factory {
 	return defaultFactory
 }
@@ -79,6 +107,8 @@ func (b *builtinRegister[U, R, O, D]) MetadataDB(db *gorm.DB) MetaDB {
 	return &builtinMetadataDB[U, R, O, D]{DB: db}
 }
 
+// decode tries each candidate by creating a fresh copy and calling Decode.
+// The first candidate that decodes without error is returned.
 func decode[T codeInterface](code string, candidate []T) (T, error) {
 	for _, v := range candidate {
 		e := newByE(v)
@@ -90,6 +120,8 @@ func decode[T codeInterface](code string, candidate []T) (T, error) {
 	return zero, fmt.Errorf("no register factory for %v", code)
 }
 
+// newByE creates a new zero-value instance of the same concrete type as e.
+// If e is a pointer, it allocates a new value of the pointed-to type.
 func newByE[E any](e E) E {
 	v := reflect.ValueOf(e)
 	if v.Kind() != reflect.Pointer {
@@ -99,6 +131,8 @@ func newByE[E any](e E) E {
 	return reflect.New(k.Type()).Interface().(E)
 }
 
+// newByT creates a new zero-value instance of type T.
+// If T is a pointer type, it allocates a new value of the pointed-to type.
 func newByT[T any]() T {
 	t := *new(T)
 	v := reflect.ValueOf(t)

--- a/schema.go
+++ b/schema.go
@@ -4,48 +4,77 @@ import (
 	"encoding/json"
 )
 
+// DirectorySearchType specifies the scope of a directory search.
+// Use [DirectorySearchAll] to include all descendants, or [DirectorySearchTop]
+// to include only direct children.
 type DirectorySearchType = string
 
+// ObjectType is a string tag that categorises objects (e.g. "role", "menu",
+// "api"). It is used to look up the correct GORM model when performing
+// object-data operations.
 type ObjectType = string
 
+// Action is a permission verb. caskin defines three built-in actions:
+// [Read], [Write], and [Manage]. Custom actions are also supported.
 type Action = string
 
+// User represents an actor in the permission system. Implementations must
+// provide an integer ID ([idInterface]) and a string encoding
+// ([codeInterface]) used as the casbin subject.
 type User interface {
 	idInterface
 	codeInterface
 }
 
+// Domain represents an isolated permission scope such as a tenant or
+// organization. Implementations must provide an integer ID and a string
+// encoding used as the casbin domain token.
 type Domain interface {
 	idInterface
 	codeInterface
 }
 
+// Role represents a named permission bundle within a domain. Roles are
+// also [ObjectData], meaning they belong to an object type and can be
+// organised in a hierarchy via [IBaseService.AddRoleG].
 type Role interface {
 	ObjectData
 	codeInterface
 }
 
+// Object represents a resource in the permission system. Objects are
+// arranged in a tree: each object may have a parent ([parentInterface]).
+// A user's read/write/manage access to a child object is implicitly
+// determined by the policy set on any ancestor.
 type Object interface {
 	idInterface
 	codeInterface
 	parentInterface
 	domainInterface
+	// GetObjectType returns the type tag for this object (e.g. "menu").
 	GetObjectType() string
 }
 
+// ObjectData represents a domain-specific data record that is protected by
+// an [Object]. For example, a "document" entity might be protected by a
+// "documents" object. Permission checks are done via the associated object.
 type ObjectData interface {
 	idInterface
 	domainInterface
-	// GetObjectID get object
+	// GetObjectID returns the ID of the protecting Object.
 	GetObjectID() uint64
-	// SetObjectID set object
+	// SetObjectID sets the ID of the protecting Object.
 	SetObjectID(uint64)
 }
 
+// IDirectory is the interface for directory search backends. It returns the
+// list of [Directory] nodes reachable from the given root ID according to
+// the specified [DirectorySearchType].
 type IDirectory interface {
 	Search(uint64, DirectorySearchType) []*Directory
 }
 
+// ID extracts the integer IDs from a slice of entities.
 func ID[E idInterface](in []E) []uint64 {
 	var m []uint64
 	for _, v := range in {
@@ -54,6 +83,7 @@ func ID[E idInterface](in []E) []uint64 {
 	return m
 }
 
+// IDMap converts a slice of entities into a map keyed by their integer ID.
 func IDMap[E idInterface](in []E) map[uint64]E {
 	m := map[uint64]E{}
 	for _, v := range in {
@@ -62,7 +92,8 @@ func IDMap[E idInterface](in []E) map[uint64]E {
 	return m
 }
 
-// Policy tuple of role-object-domain-action
+// Policy is a 4-tuple of (Role, Object, Domain, Action) that grants the
+// role permission to perform the action on the object within the domain.
 type Policy struct {
 	Role   Role   `json:"role"`
 	Object Object `json:"object"`
@@ -70,42 +101,70 @@ type Policy struct {
 	Action Action `json:"action"`
 }
 
-// Key get the unique identify of the policy
+// Key returns a stable string that uniquely identifies this policy tuple.
+// It is used internally for set-difference operations (e.g. [DiffPolicy]).
 func (p *Policy) Key() string {
 	s := []string{p.Role.Encode(), p.Object.Encode(), p.Domain.Encode(), p.Action}
 	b, _ := json.Marshal(s)
 	return string(b)
 }
 
-// UserRolePair pair of user and role
+// UserRolePair binds a user to a role. It is the unit used in
+// [IBaseService.AddUserRole] and related methods.
 type UserRolePair struct {
 	User User `json:"user"`
 	Role Role `json:"role"`
 }
 
+// Directory decorates an [Object] with aggregate counts that describe
+// the subtree rooted at that object.
 type Directory struct {
 	Object
+	// AllDirectoryCount is the total number of directory nodes in the subtree.
 	AllDirectoryCount uint64 `json:"all_directory_count"`
-	AllItemCount      uint64 `json:"all_item_count"`
+	// AllItemCount is the total number of leaf items in the subtree.
+	AllItemCount uint64 `json:"all_item_count"`
+	// TopDirectoryCount is the number of direct child directories.
 	TopDirectoryCount uint64 `json:"top_directory_count"`
-	TopItemCount      uint64 `json:"top_item_count"`
+	// TopItemCount is the number of direct child items.
+	TopItemCount uint64 `json:"top_item_count"`
 }
 
+// DirectoryRequest is the parameter bag for directory operations such as
+// [IDirectoryService.GetDirectory], [IDirectoryService.MoveDirectory], and
+// [IDirectoryService.DeleteDirectory].
 type DirectoryRequest struct {
-	To              uint64   `json:"to,omitempty"`
-	ID              []uint64 `json:"id,omitempty"`
-	Type            string   `json:"type,omitempty"`
-	Policy          string   `json:"policy,omitempty"`
-	SearchType      string   `json:"search_type,omitempty"`
-	CountDirectory  func([]uint64) (map[uint64]uint64, error)
+	// To is the target parent object ID for move operations.
+	To uint64 `json:"to,omitempty"`
+	// ID is the list of object IDs to operate on.
+	ID []uint64 `json:"id,omitempty"`
+	// Type is the ObjectType filter.
+	Type string `json:"type,omitempty"`
+	// Policy is an optional policy filter string.
+	Policy string `json:"policy,omitempty"`
+	// SearchType controls the scope of the directory traversal;
+	// see [DirectorySearchAll] and [DirectorySearchTop].
+	SearchType string `json:"search_type,omitempty"`
+	// CountDirectory is an optional callback that returns per-directory item counts.
+	CountDirectory func([]uint64) (map[uint64]uint64, error)
+	// ActionDirectory is an optional callback that performs a side effect on a set of directories.
 	ActionDirectory func([]uint64) error
 }
 
+// CountDirectoryItem is the function signature for per-directory item count
+// callbacks used in [DirectoryRequest].
 type CountDirectoryItem = func([]uint64) (map[uint64]uint64, error)
 
+// DirectoryResponse summarises the outcome of a directory move or copy
+// operation, reporting how many directories and items were already at the
+// destination ("done") versus still pending ("to-do").
 type DirectoryResponse struct {
+	// DoneDirectoryCount is the number of directories already at the destination.
 	DoneDirectoryCount uint64 `json:"done_directory_count,omitempty"`
-	DoneItemCount      uint64 `json:"done_item_count,omitempty"`
+	// DoneItemCount is the number of items already at the destination.
+	DoneItemCount uint64 `json:"done_item_count,omitempty"`
+	// ToDoDirectoryCount is the number of directories moved/copied.
 	ToDoDirectoryCount uint64 `json:"to_do_directory_count,omitempty"`
-	ToDoItemCount      uint64 `json:"to_do_item_count,omitempty"`
+	// ToDoItemCount is the number of items moved/copied.
+	ToDoItemCount uint64 `json:"to_do_item_count,omitempty"`
 }

--- a/schema_buildin.go
+++ b/schema_buildin.go
@@ -1,6 +1,9 @@
 package caskin
 
-// NamedObject build in Object for name encode/decode
+// NamedObject is the built-in [Object] implementation used for special objects
+// such as the superadmin sentinel. Its Encode/Decode methods simply use the
+// Name string, so it can represent objects that exist only in casbin policy
+// strings without corresponding database rows.
 type NamedObject struct {
 	Name string `json:"name"`
 }
@@ -39,6 +42,9 @@ func (o *NamedObject) GetObjectType() string {
 	return ""
 }
 
+// SampleSuperadminRole is the built-in [Role] that identifies the global
+// superadmin. Its Encode method always returns the [SuperadminRole] constant
+// and Decode accepts only that value, returning [ErrIsNotSuperadmin] otherwise.
 type SampleSuperadminRole struct {
 	ID   uint64 `json:"id"`
 	Name string `json:"name"`
@@ -76,6 +82,9 @@ func (s *SampleSuperadminRole) GetDomainID() uint64 {
 func (s *SampleSuperadminRole) SetDomainID(uint64) {
 }
 
+// SampleSuperadminDomain is the built-in [Domain] that represents the
+// superadmin scope. Its Encode method always returns [SuperadminDomain] and
+// Decode accepts only that value.
 type SampleSuperadminDomain struct {
 	ID   uint64 `json:"id"`
 	Name string `json:"name"`
@@ -99,6 +108,8 @@ func (s *SampleSuperadminDomain) Decode(code string) error {
 	return nil
 }
 
+// GetSuperadminRole returns a [Role] that encodes to the [SuperadminRole]
+// constant. It is used internally when granting or checking superadmin status.
 func GetSuperadminRole() Role {
 	return &SampleSuperadminRole{
 		ID:   0,
@@ -106,6 +117,9 @@ func GetSuperadminRole() Role {
 	}
 }
 
+// GetSuperadminDomain returns a [Domain] that encodes to the
+// [SuperadminDomain] constant. It is used internally alongside
+// [GetSuperadminRole] for superadmin enforcement.
 func GetSuperadminDomain() Domain {
 	return &SampleSuperadminDomain{
 		ID:   0,


### PR DESCRIPTION
## Summary

This PR adds comprehensive godoc comments to the core API files as part of **Phase 1 – Foundation Modernization** (Task 1.3 in the modernization plan).

## Changes

- **doc.go** (new): Package-level overview with key concepts, quick-start example, and architecture overview
- **schema.go**: `User`, `Role`, `Object`, `Domain`, `Policy`, `Directory`, `DirectoryRequest/Response` and all related types
- **metadata.go**: `MetaDB` interface and all method signatures with parameter/return docs
- **constant.go**: All exported constants (`ObjectPType`, `Read/Write/Manage`, `DirectorySearchAll/Top`, `UpsertType*`)
- **error.go**: All sentinel errors with context on when each is returned and `errors.Is` usage example
- **options.go**: `Options`, `Option` functional type, `DefaultSuperadmin*` vars
- **register.go**: `Factory`, `Register[U,R,O,D]`, `DefaultFactory` and unexported helpers
- **inheritance.go**: `InheritanceEdge`, `EdgeSorter`, `InheritanceGraph` and all methods
- **casbin.go**: `IEnforcer` (all 28 method docs), `SetWatcher`, `WatcherOption`, `NewEnforcer`
- **schema_buildin.go**: `NamedObject`, `SampleSuperadminRole/Domain`, `GetSuperadmin*`
- **dictionary.go**: `IDictionary`, `IFeatureDictionary`, `ICreatorDictionary`
- **metadata_database.go**: `DBOption` and its `NewDB` method

## Testing

All existing tests pass (`go test ./...`).

## Part of

Phase 1 – Foundation Modernization, Task 1.3: Enrich godoc on core public API